### PR TITLE
Actual buf max, MPI_Msg struct, and static recvd member var

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Hive-map communicator that emulates radio communication via MPI
 currently:
 
 ``` bash
-g++ *.cpp -o run-me.exe -std=c++11
+g++ ./*.cpp -o run-me.exe -std=c++11
 ```

--- a/communicator.h
+++ b/communicator.h
@@ -5,6 +5,8 @@
 #include <unistd.h>
 
 // Passive object that carries data between communicators.
+// Placed in the communicator.h file for override purposes in the MPI Radio
+// Transceiver files.
 typedef struct MPIRadioTransceiverMessage{
     // Required such that the sending transceiver does not accidentally send a
     // message to itself.

--- a/communicator.h
+++ b/communicator.h
@@ -4,6 +4,18 @@
 #include <assert.h>
 #include <unistd.h>
 
+// Passive object that carries data between communicators.
+typedef struct MPIRadioTransceiverMessage{
+    // Required such that the sending transceiver does not accidentally send a
+    // message to itself.
+    int sender_rank;       // Sending transceiver's rank.
+    int sender_id;         // Sending transceiver's unique ID.
+    double sent_x, sent_y; // The location of the sending transceiver.
+    double send_range;     // How far the sending transceiver can send.
+    char* data;            // Actual message contents.
+} MPI_Msg;
+
+
 namespace hmap {
 namespace interface {
 
@@ -25,7 +37,7 @@ public:
      *     communicator closed during the send operation
      */
     virtual ssize_t send(
-            char* data, const size_t size, const int timeout) = 0;
+            MPI_Msg* data, const size_t size, const int timeout) = 0;
 
     /**
      * Receives bytes of data from another communicator
@@ -42,7 +54,7 @@ public:
      *     (Communicator::error) or the communicator closed during the recv
      *     operation
      */
-    virtual ssize_t recv(char** data, const int timeout) = 0;
+    virtual ssize_t recv(MPI_Msg** data, const int timeout) = 0;
 
     /**
      * Idempotent method that ends send and recv capabilities and wraps up any

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -38,7 +38,7 @@ void MPIRadioTransceiver::mpi_listener(
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     // max_buffer is the largest expected message
-    const int max_msg_size = trxs[0].m_max_mpi_msgs_size;
+    const int max_msg_size = trxs[0].m_max_buffer_size;
     // mpi_msg will take in values from MPI calls
     char* mpi_msg = new char[max_msg_size];
     
@@ -100,17 +100,17 @@ void MPIRadioTransceiver::mpi_listener(
                     // can be modified (albeit only shrunken) by t.
                     // A potential optimization would be to skip for later 
                     // if can't get lock.
-                    lock_guard<mutex> mpi_msgs_lock(t.m_mpi_msgs_mtx);
+                    lock_guard<mutex> buffer_lock(t.m_buffer_mtx);
                     // move memory to buffer on transceiver
-                    memcpy(t.m_mpi_msgs + t.m_mpi_msgs_size, mpi_msg, msg_size);
+                    memcpy(t.m_buffer + t.m_buffer_size, mpi_msg, msg_size);
                     // adjust size
-                    t.m_mpi_msgs_size += msg_size;
-                    cout << "size: "<< t.m_mpi_msgs_size << endl;
+                    t.m_buffer_size += msg_size;
+                    cout << "size: "<< t.m_buffer_size << endl;
                 }
                 // SHORT BUSY WAIT
                 while(t.m_receiving) {
                     // ends any blocking mutexes
-                    t.m_mpi_msgs_flag.notify_all();
+                    t.m_buffer_flag.notify_all();
                 }
             }
         }
@@ -170,7 +170,7 @@ MPIRadioTransceiver::MPIRadioTransceiver() {
 
 ssize_t MPIRadioTransceiver::send(
         char* data, const size_t size, const int timeout) {
-    if(size > m_max_mpi_msgs_size) {
+    if(size > m_max_buffer_size) {
         return Communicator::error;
     }
     // iterate through all ranks and send data
@@ -183,19 +183,19 @@ ssize_t MPIRadioTransceiver::send(
 }
 
 ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
-    if(m_mpi_msgs_size == 0) {
+    if(m_buffer_size == 0) {
         m_receiving = true;
         mutex mtx;
         unique_lock<mutex> lk(mtx);
-        m_mpi_msgs_flag.wait_for(
+        m_buffer_flag.wait_for(
                 lk, // lock to block on  
                 milliseconds(timeout), // time to wait on
-                [this]{ return m_mpi_msgs_size > 0; }); // conditional to wait for
+                [this]{ return m_buffer_size > 0; }); // conditional to wait for
         m_receiving = false;
     }
     // now see if there is data in the buffer
-    if(m_mpi_msgs_size > 0) { // there is data in the buffer
-        *data = m_mpi_msgs; // this will do for now...
+    if(m_buffer_size > 0) { // there is data in the mpi msg buffer
+        *data = m_buffer; // this will do for now...
         m_receiving = false;
         return 1;
         // TODO get actual size

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -37,7 +37,7 @@ void MPIRadioTransceiver::mpi_listener(
     int rank = 0;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    // max_buffer is the largest expected message
+    // max_msg_size is the largest expected message
     const int max_msg_size = trxs[0].m_max_buffer_size;
     // mpi_msg will take in values from MPI calls
     char* mpi_msg = new char[max_msg_size];

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -193,14 +193,14 @@ ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
                 [this]{ return m_mpi_msgs_size > 0; }); // conditional to wait for
         m_receiving = false;
     }
-    // now see if there is data in the buffer
-    if(m_mpi_msgs_size > 0) { // there is data in the buffer
+    // now see if there are any mpi_msgs
+    if(m_mpi_msgs_size > 0) { // there is data in the mpi_msgs buffer
         *data = m_mpi_msgs; // this will do for now...
         m_receiving = false;
         return 1;
-        // TODO get actual size
-        // TODO shrink buffer (need buffer_mtx for that)
-        // TODO copy over buffer to newly allcoated memory
+        // TODO Calculate actual size from data offsets
+        // TODO Shrink mpi_msgs (need mpi_msgs_mtx for that)
+        // TODO copy over mpi_msg to newly allocated mpi_msgs memory
     } else {
         return 0; // nothing in buffer and timeout reached
     }

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -94,6 +94,8 @@ void MPIRadioTransceiver::mpi_listener(
             // is not maxed out)
             for(size_t i = 0; i < trxs_size; ++i) {
                 auto& t = trxs[i];
+                // Cast mpi_msg back to its original data type.
+                MPI_Msg* mpi_msg = (MPI_Msg*) mpi_msg;
                 // Check if mpi_msg buffer is maxed out; if so, drop message.
                 if (t.m_buffer_size + mpi_msg_size > t.m_max_buffer_size) {
                     continue;

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -94,8 +94,6 @@ void MPIRadioTransceiver::mpi_listener(
             // is not maxed out)
             for(size_t i = 0; i < trxs_size; ++i) {
                 auto& t = trxs[i];
-                // Cast mpi_msg back to its original data type.
-                MPI_Msg* mpi_msg = (MPI_Msg*) mpi_msg;
                 // Check if mpi_msg buffer is maxed out; if so, drop message.
                 if (t.m_buffer_size + mpi_msg_size > t.m_max_buffer_size) {
                     continue;
@@ -173,7 +171,7 @@ MPIRadioTransceiver::MPIRadioTransceiver() {
 }
 
 ssize_t MPIRadioTransceiver::send(
-        char* data, const size_t size, const int timeout) {
+        MPI_Msg* data, const size_t size, const int timeout) {
     if(size > m_max_buffer_size) {
         return Communicator::error;
     }
@@ -186,7 +184,7 @@ ssize_t MPIRadioTransceiver::send(
     return size;
 }
 
-ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
+ssize_t MPIRadioTransceiver::recv(MPI_Msg** data, const int timeout) {
     if(m_buffer_size == 0) {
         m_receiving = true;
         mutex mtx;

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -169,7 +169,7 @@ MPIRadioTransceiver::MPIRadioTransceiver() {
 }
 
 ssize_t MPIRadioTransceiver::send(
-        char* data, const size_t size, const int timeout) {
+        MPI_Message* data, const size_t size, const int timeout) {
     if(size > m_max_mpi_msgs_size) {
         return Communicator::error;
     }
@@ -182,7 +182,7 @@ ssize_t MPIRadioTransceiver::send(
     return size;
 }
 
-ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
+ssize_t MPIRadioTransceiver::recv(MPI_Message** data, const int timeout) {
     if(m_mpi_msgs_size == 0) {
         m_receiving = true;
         mutex mtx;
@@ -195,7 +195,7 @@ ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
     }
     // now see if there are any mpi_msgs
     if(m_mpi_msgs_size > 0) { // there is data in the mpi_msgs buffer
-        *data = m_mpi_msgs; // this will do for now...
+        *data = (MPI_Message*) m_mpi_msgs; // this will do for now...
         m_receiving = false;
         return 1;
         // TODO Calculate actual size from data offsets

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -42,7 +42,7 @@ void MPIRadioTransceiver::mpi_listener(
     // mpi_msg will take in values from MPI calls
     MPI_Msg* mpi_msg = new MPI_Msg;
 
-    // Set up creation of the MPI_Msg MPI Datatype.
+    // Set up creation of the MPI_Msg MPI_Datatype.
     const int block_counts = 3; // Number of blocks.
     // Data types contained in the struct.
     MPI_Datatype block_types[block_counts] = {
@@ -54,7 +54,7 @@ void MPIRadioTransceiver::mpi_listener(
         offsetof(MPI_Msg, sent_x),
         offsetof(MPI_Msg, data)
     };
-    // Creates the MPI Datatype and commits.
+    // Creates the MPI_Datatype and commits.
     MPI_Datatype MPI_MSG_DT; // MPI wrapper for the MPI_Msg struct.
     MPI_Type_create_struct(
         block_counts, block_lengths, block_offsets, block_types, &MPI_MSG_DT);

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -94,14 +94,16 @@ void MPIRadioTransceiver::mpi_listener(
             // is not maxed out)
             for(size_t i = 0; i < trxs_size; ++i) {
                 auto& t = trxs[i];
-                // check if mpi_msg buffer is maxed out, if so drop message
-                { // MPI_MSG BUFFER LOCK
+                // Check if mpi_msg buffer is maxed out; if so, drop message.
+                if (t.m_buffer_size + mpi_msg_size > t.m_max_buffer_size) {
+                    continue;
+                } else { // MPI_MSG BUFFER LOCK
                     // NOTE: this section is locked because the t.m_buffer
                     // can be modified (albeit only shrunken) by t.
                     // A potential optimization would be to skip for later 
                     // if can't get lock.
                     lock_guard<mutex> buffer_lock(t.m_buffer_mtx);
-                    // move memory to buffer on transceiver
+                    // move mpi_msg data to buffer on transceiver
                     memcpy(t.m_buffer + t.m_buffer_size, mpi_msg, mpi_msg_size);
                     // adjust size
                     t.m_buffer_size += mpi_msg_size;

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -42,7 +42,7 @@ void MPIRadioTransceiver::mpi_listener(
     // mpi_msg will take in values from MPI calls
     MPI_Msg* mpi_msg = new MPI_Msg;
 
-    // Set up creation of the MPI_Msg MPI_Datatype.
+    // Set up creation of the MPI_Msg MPI Datatype.
     const int block_counts = 3; // Number of blocks.
     // Data types contained in the struct.
     MPI_Datatype block_types[block_counts] = {
@@ -54,7 +54,7 @@ void MPIRadioTransceiver::mpi_listener(
         offsetof(MPI_Msg, sent_x),
         offsetof(MPI_Msg, data)
     };
-    // Creates the MPI_Datatype and commits.
+    // Creates the MPI Datatype and commits.
     MPI_Datatype MPI_MSG_DT; // MPI wrapper for the MPI_Msg struct.
     MPI_Type_create_struct(
         block_counts, block_lengths, block_offsets, block_types, &MPI_MSG_DT);
@@ -218,10 +218,13 @@ ssize_t MPIRadioTransceiver::recv(MPI_Msg** data, const int timeout) {
     }
     // now see if there is data in the buffer
     if(m_buffer_size > 0) { // there is data in the mpi msg buffer
-        *data = m_buffer; // this will do for now...
+        // Siphon off the received mpi msg off the buffer.
+        memcpy(m_buffer, m_recvd_msg, sizeof(MPI_Msg));
+        *data = m_recvd_msg; // this will do for now...
         m_receiving = false;
         return 1;
-        // TODO Calculate actual size from data offsets
+        // TODO Calculate actual size from data offsets (not MPI_Msg)
+        // TODO Remove siphoned off message from buffer
         // TODO Shrink buffer size (need buffer_mtx for that)
         // TODO copy over buffer to newly re-allocated buffer memory
     } else {

--- a/mpi_radio_transceiver.cpp
+++ b/mpi_radio_transceiver.cpp
@@ -50,7 +50,7 @@ void MPIRadioTransceiver::mpi_listener(
 
     // MPI received meta information
     MPI_Status status; // was the receive successful?
-    int msg_size = 0; // how many bytes were received?
+    int mpi_msg_size = 0; // how many bytes were received?
     char close_status = 0; // was the close clean?
     int channel; // the channel that became unblocked
     // Set up a non-blocking receive for the thread ending
@@ -88,7 +88,7 @@ void MPIRadioTransceiver::mpi_listener(
             break;
         } else if(channel == RECV_CHANNEL) {
             // get size of the MPI msg
-            MPI_Get_count(&status, MPI_BYTE, &msg_size);
+            MPI_Get_count(&status, MPI_BYTE, &mpi_msg_size);
             // Iterate through transceivers and load their mpi_msg buffers up
             // with new information (if it pertains to them, and their buffer
             // is not maxed out)
@@ -102,9 +102,9 @@ void MPIRadioTransceiver::mpi_listener(
                     // if can't get lock.
                     lock_guard<mutex> buffer_lock(t.m_buffer_mtx);
                     // move memory to buffer on transceiver
-                    memcpy(t.m_buffer + t.m_buffer_size, mpi_msg, msg_size);
+                    memcpy(t.m_buffer + t.m_buffer_size, mpi_msg, mpi_msg_size);
                     // adjust size
-                    t.m_buffer_size += msg_size;
+                    t.m_buffer_size += mpi_msg_size;
                     cout << "size: "<< t.m_buffer_size << endl;
                 }
                 // SHORT BUSY WAIT
@@ -199,8 +199,8 @@ ssize_t MPIRadioTransceiver::recv(char** data, const int timeout) {
         m_receiving = false;
         return 1;
         // TODO Calculate actual size from data offsets
-        // TODO Shrink mpi_msgs (need mpi_msgs_mtx for that)
-        // TODO copy over mpi_msg to newly allocated mpi_msgs memory
+        // TODO Shrink buffer size (need buffer_mtx for that)
+        // TODO copy over buffer to newly re-allocated buffer memory
     } else {
         return 0; // nothing in buffer and timeout reached
     }

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -44,6 +44,7 @@ public:
     static MPIRadioTransceiver* transceivers() {
         static MPIRadioTransceiver trxs[N];
         static MPI_Msg buffers[N][B * sizeof(MPI_Msg)];
+        static MPI_Msg recvd_msgs[N][sizeof(MPI_Msg)];
 
         // Initializes each transceiver.
         for(size_t i = 0; i < N; ++i) {
@@ -51,8 +52,9 @@ public:
             t.m_max_buffer_size = (B * sizeof(MPI_Msg));
             t.m_buffer_size = 0;
             t.m_buffer = buffers[i];
-            t.m_recvd_msg = new char[sizeof(MPI_Msg)];
+            t.m_recvd_msg = recvd_msgs[i];
         }
+
         if(!open_mpi_listener(trxs, N)) {
             // could not start listener, something's wrong
             return nullptr;
@@ -110,8 +112,8 @@ private:
     static const int RECV_CHANNEL = 0;
     static const int CLOSE_CHANNEL = 1;
 
-    // Pointer used to siphon off a received message off the buffer.
-    static char* m_recvd_msg;
+    // Pointer used to siphon off a received MPI message off the buffer.
+    MPI_Msg* m_recvd_msg;
 
     // can only create transcievers through template transceivers
     MPIRadioTransceiver();

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -46,6 +46,7 @@ public:
 
         for(int i = 0; i < N; ++i) {
             auto& t = trxs[i];
+            t.m_id = i;
             t.m_max_mpi_msgs_size = B;
             t.m_mpi_msgs_size = 0;
             t.m_mpi_msgs = mpi_msgs[i];
@@ -68,6 +69,10 @@ public:
 
 
 private:
+    // Identifier unique to each transceiver.
+    // Prevents transceivers from receiving their own messages.
+    int m_id;
+
     // transceiver parameters
     double m_x;
     double m_y;
@@ -124,8 +129,6 @@ private:
      * Stops the mpi listener
      */
     static void close_mpi_listener();
-
-
 };
 
 #endif // MPI_RADIO_TRANSCEIVER_H

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -38,7 +38,7 @@ public:
      *
      * Template Args:
      *     N: number of transceivers
-     *     B: max buffer size
+     *     B: max elements in buffer
      */
     template<size_t N, size_t B>
     static MPIRadioTransceiver* transceivers() {
@@ -48,9 +48,10 @@ public:
         // Initializes each transceiver.
         for(size_t i = 0; i < N; ++i) {
             auto& t = trxs[i];
-            t.m_max_buffer_size = B + (B * sizeof(MPI_Msg));
+            t.m_max_buffer_size = (B * sizeof(MPI_Msg));
             t.m_buffer_size = 0;
             t.m_buffer = buffers[i];
+            t.m_recvd_msg = new char[sizeof(MPI_Msg)];
         }
         if(!open_mpi_listener(trxs, N)) {
             // could not start listener, something's wrong
@@ -108,6 +109,9 @@ private:
     // mpi channels used
     static const int RECV_CHANNEL = 0;
     static const int CLOSE_CHANNEL = 1;
+
+    // Pointer used to siphon off a received message off the buffer.
+    static char* m_recvd_msg;
 
     // can only create transcievers through template transceivers
     MPIRadioTransceiver();

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -42,13 +42,13 @@ public:
     template<size_t N, size_t B>
     static MPIRadioTransceiver* transceivers() {
         static MPIRadioTransceiver trxs[N];
-        static char buffers[N][B]; // TODO GROW OUT TO ACTUAL MAX BUFFER
+        static char mpi_msgs[N][B]; // TODO GROW OUT TO ACTUAL MAX BUFFER
 
         for(int i = 0; i < N; ++i) {
             auto& t = trxs[i];
-            t.m_max_buffer_size = B;
-            t.m_buffer_size = 0;
-            t.m_buffer = buffers[i];
+            t.m_max_mpi_msgs_size = B;
+            t.m_mpi_msgs_size = 0;
+            t.m_mpi_msgs = mpi_msgs[i];
         }
         if(!open_mpi_listener(trxs, N)) {
             // could not start listener, somethings wrong
@@ -76,16 +76,16 @@ private:
     double m_send_radius;
     double m_recv_radius;
 
-    // buffer variables
-    char* m_buffer; // buffer information gets packed into
-    std::mutex m_buffer_mtx; // serializes changes to the array
-    // conditional that fires when buffer has received data
-    std::condition_variable m_buffer_flag; 
-    // amount of data in the buffer currently
-    size_t m_buffer_size = 0;
-    // largest amount of data possible in the buffer, if this high-water mark is
-    // reached then messages will be dropped
-    size_t m_max_buffer_size;
+    // mpi_msg buffer variables
+    char* m_mpi_msgs; // buffer information gets packed into
+    std::mutex m_mpi_msgs_mtx; // serializes changes to the array
+    // conditional that fires when an MPI message has been received.
+    std::condition_variable m_mpi_msgs_flag; 
+    // amount of data in the MPI msgs buffer currently
+    size_t m_mpi_msgs_size = 0;
+    // largest amount of data possible in the mpi msgs buffer, if this
+    // high-water mark is reached then messages will be dropped.
+    size_t m_max_mpi_msgs_size;
     // triggered when the transceiver is receiving information
     bool m_receiving = false;
 

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -46,9 +46,9 @@ public:
 
         for(int i = 0; i < N; ++i) {
             auto& t = trxs[i];
-            t.m_max_mpi_msgs_size = B;
-            t.m_mpi_msgs_size = 0;
-            t.m_mpi_msgs = mpi_msgs[i];
+            t.m_max_buffer_size = B;
+            t.m_buffer_size = 0;
+            t.m_buffer = mpi_msgs[i];
         }
         if(!open_mpi_listener(trxs, N)) {
             // could not start listener, somethings wrong
@@ -77,15 +77,15 @@ private:
     double m_recv_radius;
 
     // mpi_msg buffer variables
-    char* m_mpi_msgs; // buffer information gets packed into
-    std::mutex m_mpi_msgs_mtx; // serializes changes to the array
+    char* m_buffer; // buffer information gets packed into
+    std::mutex m_buffer_mtx; // serializes changes to the array
     // conditional that fires when an MPI message has been received.
-    std::condition_variable m_mpi_msgs_flag; 
+    std::condition_variable m_buffer_flag; 
     // amount of data in the MPI msgs buffer currently
-    size_t m_mpi_msgs_size = 0;
-    // largest amount of data possible in the mpi msgs buffer, if this
+    size_t m_buffer_size = 0;
+    // largest amount of data possible in the buffer, if this
     // high-water mark is reached then messages will be dropped.
-    size_t m_max_mpi_msgs_size;
+    size_t m_max_buffer_size;
     // triggered when the transceiver is receiving information
     bool m_receiving = false;
 

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -42,13 +42,13 @@ public:
     template<size_t N, size_t B>
     static MPIRadioTransceiver* transceivers() {
         static MPIRadioTransceiver trxs[N];
-        static char buffer[N][B]; // TODO GROW OUT TO ACTUAL MAX BUFFER
+        static char buffers[N][B]; // TODO GROW OUT TO ACTUAL MAX BUFFER
 
         for(size_t i = 0; i < N; ++i) {
             auto& t = trxs[i];
             t.m_max_buffer_size = B;
             t.m_buffer_size = 0;
-            t.m_buffer = buffer[i];
+            t.m_buffer = buffers[i];
         }
         if(!open_mpi_listener(trxs, N)) {
             // could not start listener, somethings wrong
@@ -80,7 +80,7 @@ private:
     double m_send_radius;
     double m_recv_radius;
 
-    // mpi_msg buffer variables
+    // Buffer variables.
     char* m_buffer; // buffer information gets packed into
     std::mutex m_buffer_mtx; // serializes changes to the array
     // conditional that fires when an MPI message has been received.

--- a/mpi_radio_transceiver.h
+++ b/mpi_radio_transceiver.h
@@ -44,7 +44,7 @@ public:
         static MPIRadioTransceiver trxs[N];
         static char buffer[N][B]; // TODO GROW OUT TO ACTUAL MAX BUFFER
 
-        for(int i = 0; i < N; ++i) {
+        for(size_t i = 0; i < N; ++i) {
             auto& t = trxs[i];
             t.m_max_buffer_size = B;
             t.m_buffer_size = 0;

--- a/mpi_tests.cpp
+++ b/mpi_tests.cpp
@@ -61,14 +61,24 @@ int main(int argc, char** argv) {
     // ENSURES: all transceivers done with adjusting their locations
     MPI_Barrier(MPI_COMM_WORLD); 
 
-    // This Test selects moves around the first transceiver index and sees if
+    // This test selects moves around the first transceiver index and sees if
     // where it broadcasts changes
     if(rank == 0) {
-        char m = 'h';
-        trxs[0].send(&m, 1, 0);
-        char* j = &m;
-        trxs[0].recv(&j, 1000); // wait for 1 second, TODO switch to float
-        cout << j[0] << endl;
+        MPI_Msg msg;
+        msg.data = "h";
+        msg.send_range = 1;
+        msg.sender_id = 0;
+        msg.sender_rank = rank;
+        msg.sent_x = trxs[0].get_x();
+        msg.sent_y = trxs[0].get_y();
+        // char m = 'h';
+        trxs[0].send((char*)&msg, sizeof(msg), 0);
+        char* recv_msg = (char*) &msg;
+        // char* j = &m;
+        trxs[0].recv(&recv_msg, 1000); // wait for 1 second, TODO switch to float
+        // cout << j[0] << endl;
+        // MPI_Msg* recv_msg = (MPI_Msg*) recv_msg;
+        cout << ((MPI_Msg*) recv_msg)->data << endl;
         /*
         auto& t = trxs[0];
         for(int i = 0; i < NUM_TRXS; ++i) {

--- a/mpi_tests.cpp
+++ b/mpi_tests.cpp
@@ -35,11 +35,6 @@ int main(int argc, char** argv) {
     int num_ranks;
     MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
 
-    // each context is one away from i
-    // VISUALIZATION:
-    // x-location:  0.....1.....2......3......4
-    //            t[0]  t[1]  t[2]   t[3]   t[4]
-    // each transceiver is '1' unit away from the others
     auto trxs = MPIRadioTransceiver::transceivers<NUM_TRXS, MAX_BUFFER_SIZE>();
     if(trxs == nullptr) {
         // could not get transceivers
@@ -47,6 +42,11 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // each context is one away from i
+    // VISUALIZATION:
+    // x-location:  0.....1.....2......3......4
+    //            t[0]  t[1]  t[2]   t[3]   t[4]
+    // each transceiver is '1' unit away from the others
     for(int i = 0; i < NUM_TRXS; ++i) {
         auto& t = trxs[i];
         // setting parameters for t
@@ -64,21 +64,18 @@ int main(int argc, char** argv) {
     // This test selects moves around the first transceiver index and sees if
     // where it broadcasts changes
     if(rank == 0) {
-        MPI_Msg msg;
-        msg.data = "h";
-        msg.send_range = 1;
-        msg.sender_id = 0;
-        msg.sender_rank = rank;
-        msg.sent_x = trxs[0].get_x();
-        msg.sent_y = trxs[0].get_y();
-        // char m = 'h';
-        trxs[0].send((char*)&msg, sizeof(msg), 0);
-        char* recv_msg = (char*) &msg;
-        // char* j = &m;
+        MPI_Msg mpi_msg;
+        char msg_contents = 'H';
+        mpi_msg.data = (char*) (&msg_contents);
+        mpi_msg.send_range = 1;
+        mpi_msg.sender_id = 0;
+        mpi_msg.sender_rank = rank;
+        mpi_msg.sent_x = trxs[0].get_x();
+        mpi_msg.sent_y = trxs[0].get_y();
+        trxs[0].send(&mpi_msg, sizeof(mpi_msg), 0);
+        MPI_Msg* recv_msg = (MPI_Msg*) &mpi_msg;
         trxs[0].recv(&recv_msg, 1000); // wait for 1 second, TODO switch to float
-        // cout << j[0] << endl;
-        // MPI_Msg* recv_msg = (MPI_Msg*) recv_msg;
-        cout << ((MPI_Msg*) recv_msg)->data << endl;
+        cout << "Data: " << recv_msg->data << endl;
         /*
         auto& t = trxs[0];
         for(int i = 0; i < NUM_TRXS; ++i) {
@@ -101,10 +98,17 @@ int main(int argc, char** argv) {
             assert(t.recv(&raw_msg, 0) == 0);
         }*/
     } else { // another rank make sure messages get received
+        MPI_Msg mpi_msg;
         char p = 'a';
-        char* m = &p;
-        trxs[0].recv(&m, 1000);
-        cout << m[0] << endl;
+        mpi_msg.data = (char*)(&p);
+        mpi_msg.send_range = 1;
+        mpi_msg.sender_id = 0;
+        mpi_msg.sender_rank = rank;
+        mpi_msg.sent_x = trxs[0].get_x();
+        mpi_msg.sent_y = trxs[0].get_y();
+        MPI_Msg* recv_msg = (MPI_Msg*) (&mpi_msg);
+        trxs[0].recv(&recv_msg, 1000);
+        cout << "Data: " << recv_msg->data << endl;
         /*
         for(int i = 0; i < NUM_TRXS; ++i) {
             auto& t = trxs[i];


### PR DESCRIPTION
- Set buffer max to its actual maximum (including the preceding header data).
- Created MPI_Msg struct passed between transceivers and integrated it in current code.
- Created MPI_Datatype wrapper for MPI_Msg struct.
- Meh implementation of checking if transceiver's buffer is full & received message isn't from self.

Notes:
EDIT:
After messing around with tests, realized that creating the Datatype would benefit us in the future for accessing the message's header/body in function so it's better if we did use MPI_Type_create_struct, just kind of a pain to create with the manual entries. Let me know if there's a better way since it doesn't give way to scalable modular coding :-P

Original:
- Prefer current implementation, or move the check to after the buffer lock is obtained:
https://github.com/gregjhansell97/mpi-radio-transceiver/blob/99721c5eed8ab162d5cc9706fdd4294c4ae05fc9/mpi_radio_transceiver.cpp#L95-L103
t can shrink the t.m_buffer, which might allow enough room for this new msg in the buffer variable...?

- Struct declaration placed within the communicator.h file for override purposes. I'm not sure if it's best code practice, let me know if there's a better way!
- MPI_Msg current implementation is not the [best practice method](https://stackoverflow.com/a/9865041); but I see no issues with this. MPI_Msgs are the only data types that transceivers send/receive. There's no need in using MPI_Type_create_struct (makes the code less modular, more manual coding of types/offsets/etc.), please advise!